### PR TITLE
NBA playoff bracket: proper bracket layout + mobile swipe + connectors

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -53,12 +53,23 @@
     grid-template-rows: auto 1px auto;
     column-gap: 24px;
     align-items: stretch;
+    position: relative;
   }
   .round { display: contents; }
   .conf-sep {
     grid-column: 1 / 4; grid-row: 2;
     background: var(--rule); height: 1px;
+    z-index: 1;
   }
+  .bracket-lines {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%;
+    pointer-events: none; z-index: 0;
+    overflow: visible;
+  }
+  .bracket-lines path { stroke: var(--rule); stroke-width: 1; fill: none; }
+  .match { z-index: 1; }
+  @media (max-width: 900px) { .bracket-lines { display: none; } }
   .conf-group { display: flex; flex-direction: column; padding: 20px 0; min-width: 0; }
   .round.r1 .conf-group    { grid-column: 1; }
   .round.semis .conf-group { grid-column: 2; }
@@ -70,7 +81,7 @@
   .round.semis .conf-group.west,
   .round.cf .conf-group.west { grid-row: 3; }
   .round.finals {
-    display: flex; flex-direction: column; justify-content: center;
+    display: flex; flex-direction: column;
     grid-column: 4; grid-row: 1 / 4;
     padding: 20px 0;
   }
@@ -88,20 +99,18 @@
     font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
     color: var(--dim); font-weight: 600; margin-bottom: 12px;
   }
-  .round.finals .col-title { text-align: left; }
 
   /* round-nav shows only on mobile */
   .round-nav { display: none; }
 
-  .match, .finals-card {
+  .match {
     background: var(--panel); border: 1px solid var(--rule);
     padding: 10px 12px; position: relative;
   }
-  .match .round-tag, .finals-card .round-tag {
+  .match .round-tag {
     display: block; font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
     color: var(--dim); margin-bottom: 8px;
   }
-  .finals-card { border: 2px solid var(--rule-strong); }
 
   .team {
     display: grid; grid-template-columns: 20px 1fr auto; align-items: center;
@@ -142,10 +151,8 @@
   }
   .expand-btn:hover { color: var(--ink); }
   .expand-btn .expand-open { display: none; }
-  .match.expanded .expand-btn .expand-closed,
-  .finals-card.expanded .expand-btn .expand-closed { display: none; }
-  .match.expanded .expand-btn .expand-open,
-  .finals-card.expanded .expand-btn .expand-open { display: inline; }
+  .match.expanded .expand-btn .expand-closed { display: none; }
+  .match.expanded .expand-btn .expand-open { display: inline; }
 
   footer.foot {
     margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--rule);
@@ -325,8 +332,7 @@ function teamRow(t, isFav) {
 
 let _slotSeq = 0;
 function slotCard(s, opts = {}) {
-  const { variant, maxShown = 5, label } = opts;
-  const cls = variant === "finals" ? "finals-card" : "match";
+  const { maxShown = 5, label } = opts;
   const id = `slot-${_slotSeq++}`;
   const eligible = s.cands.filter(c => c.win > 0.0005 || c.appear > 0.001);
   const shown = eligible.slice(0, maxShown);
@@ -339,8 +345,8 @@ function slotCard(s, opts = {}) {
       <span class="expand-closed">+ ${rest.length} more · ${fmtPct(restWin)}</span>
       <span class="expand-open">collapse</span>
     </button>` : "";
-  const header = `<div class="round-tag">${variant === "finals" ? "NBA Finals" : (label || s.slot)}</div>`;
-  return `<div class="${cls}" id="${id}">
+  const header = `<div class="round-tag">${label || s.slot}</div>`;
+  return `<div class="match" id="${id}">
     ${header}
     <div class="rows-collapsed">${collapsedRows}</div>
     <div class="rows-expanded" hidden>${expandedRows}</div>
@@ -400,6 +406,7 @@ function render(slotList, { nSims, year }) {
     <button type="button" data-round="finals">Finals</button>
   </nav>
   <div class="bracket" id="bracket">
+    <svg class="bracket-lines" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"></svg>
     <div class="conf-sep" aria-hidden="true"></div>
     ${roundSection("r1",
       e_r1.map(s => slotCard(s, { maxShown: 4, label: r1Label(s) })).join(""),
@@ -415,7 +422,7 @@ function render(slotList, { nSims, year }) {
       "East · Conf Finals", "West · Conf Finals")}
     <div class="round finals" data-round="finals">
       <div class="col-title">Finals</div>
-      <div class="col-cards">${fin.map(s => slotCard(s, { variant: "finals", maxShown: 10 })).join("")}</div>
+      <div class="col-cards">${fin.map(s => slotCard(s, { maxShown: 10, label: "NBA Finals" })).join("")}</div>
     </div>
   </div>
   `;
@@ -463,6 +470,88 @@ function render(slotList, { nSims, year }) {
       }
     }, 60);
   }, { passive: true });
+
+  // Draw bracket connector lines (desktop only)
+  requestAnimationFrame(drawBracketLines);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(drawBracketLines);
+  }
+  let resizeTimer;
+  window.addEventListener("resize", () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(drawBracketLines, 80);
+  });
+  // Redraw after a card is expanded/collapsed since heights shift.
+  document.querySelectorAll(".expand-btn").forEach(btn => {
+    btn.addEventListener("click", () => setTimeout(drawBracketLines, 0));
+  });
+}
+
+function drawBracketLines() {
+  const bracket = document.getElementById("bracket");
+  if (!bracket) return;
+  const svg = bracket.querySelector(".bracket-lines");
+  if (!svg) return;
+  while (svg.firstChild) svg.removeChild(svg.firstChild);
+  if (window.innerWidth <= 900) return;
+
+  const bRect = bracket.getBoundingClientRect();
+  svg.setAttribute("viewBox", `0 0 ${bRect.width} ${bRect.height}`);
+  svg.setAttribute("width", bRect.width);
+  svg.setAttribute("height", bRect.height);
+
+  const q = sel => Array.from(document.querySelectorAll(sel));
+  const r1 = {
+    east: q(".round.r1 .conf-group.east .match"),
+    west: q(".round.r1 .conf-group.west .match")
+  };
+  const semis = {
+    east: q(".round.semis .conf-group.east .match"),
+    west: q(".round.semis .conf-group.west .match")
+  };
+  const cf = {
+    east: q(".round.cf .conf-group.east .match"),
+    west: q(".round.cf .conf-group.west .match")
+  };
+  const finals = document.querySelector(".round.finals .match");
+
+  const rect = el => {
+    const r = el.getBoundingClientRect();
+    return {
+      left: r.left - bRect.left,
+      right: r.right - bRect.left,
+      midY: (r.top + r.bottom) / 2 - bRect.top
+    };
+  };
+
+  const parts = [];
+  const connect = (f1el, f2el, nextEl) => {
+    const f1 = rect(f1el), f2 = rect(f2el), n = rect(nextEl);
+    const midX = (Math.max(f1.right, f2.right) + n.left) / 2;
+    parts.push(`M ${f1.right} ${f1.midY} L ${midX} ${f1.midY}`);
+    parts.push(`M ${f2.right} ${f2.midY} L ${midX} ${f2.midY}`);
+    parts.push(`M ${midX} ${f1.midY} L ${midX} ${f2.midY}`);
+    parts.push(`M ${midX} ${n.midY} L ${n.left} ${n.midY}`);
+  };
+
+  ["east", "west"].forEach(conf => {
+    if (r1[conf].length === 4 && semis[conf].length === 2) {
+      connect(r1[conf][0], r1[conf][1], semis[conf][0]);
+      connect(r1[conf][2], r1[conf][3], semis[conf][1]);
+    }
+    if (semis[conf].length === 2 && cf[conf].length === 1) {
+      connect(semis[conf][0], semis[conf][1], cf[conf][0]);
+    }
+  });
+  if (cf.east.length === 1 && cf.west.length === 1 && finals) {
+    connect(cf.east[0], cf.west[0], finals);
+  }
+
+  if (parts.length) {
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", parts.join(" "));
+    svg.appendChild(path);
+  }
 }
 
 loadAndRender().catch(err => {

--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -75,9 +75,14 @@
     padding: 20px 0;
   }
 
+  /* equal-height tracks + center-aligned cards so next-round games land
+     exactly at the midpoint of the two games that feed them, regardless
+     of individual card content height */
   .col-cards {
-    flex: 1; display: flex; flex-direction: column;
-    justify-content: space-around; gap: 16px;
+    flex: 1; display: grid;
+    grid-auto-rows: minmax(0, 1fr);
+    align-items: center;
+    gap: 16px;
   }
   .col-title {
     font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
@@ -193,7 +198,10 @@
       padding: 16px 0;
     }
     .conf-group.west { border-top: 1px solid var(--rule); }
-    .col-cards { justify-content: flex-start; }
+    .col-cards {
+      display: flex; flex-direction: column;
+      justify-content: flex-start; gap: 16px;
+    }
 
     /* round indicator bar above the scroll area */
     .round-nav {


### PR DESCRIPTION
## Summary
- Reorganize the NBA playoff bracket so each next-round card sits at the vertical midpoint of the two games feeding into it (Semis between R1 pairs, CF between Semis, Finals between East/West CF).
- Make the page mobile-friendly: horizontal scroll with `scroll-snap-type: x mandatory` so one swipe advances exactly one round, with a round-nav bar at the top that highlights the active round.
- Normalize the Finals card to look identical to the other round cards (no thick border, title at top of column like the others).
- Add classic bracket connector lines via an SVG overlay that measures card positions and draws horizontal+vertical joiners from each feeder pair into the next card. Redraws on resize, font load, and expand/collapse.

## Test plan
- [ ] Load `/nba/playoffs/` on desktop (≥901px): Semis cards land on the midpoint of each R1 pair, CF on midpoint of Semis, Finals on midpoint of East/West CF; connector lines join each pair cleanly.
- [ ] Tablet (701–900px): Finals drops to a centered row below; connector lines are hidden.
- [ ] Mobile (≤700px): horizontal scroll with snap — each swipe shows exactly one round; round-nav buttons update on scroll and jump on tap.
- [ ] Expand a card with "+N more": lines redraw and everything stays aligned.
- [ ] Resize the window: lines redraw to match the new layout.

https://claude.ai/code/session_01EL3TfZAkxxNfkP38Tfguep