### PR TITLE
NBA playoff bracket: shrink series-length legend bars

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -36,7 +36,7 @@
     padding-bottom: 14px; border-bottom: 1px solid var(--rule);
   }
   .legend .swatch { display: inline-flex; align-items: center; gap: 6px; }
-  .legend .bar-demo { display: inline-flex; height: 4px; width: 80px; }
+  .legend .bar-demo { display: inline-flex; height: 4px; width: 28px; }
   .legend .bar-demo span { flex: 1; }
 
   .loading { text-align: center; padding: 60px 20px; color: var(--dim); font-size: 13px; }


### PR DESCRIPTION
## Summary
- Shrink the "Series length" legend bars in the NBA playoff bracket from 80px wide to 28px (~1/3 the previous size) so the legend reads more compactly.

## Test plan
- [ ] Load `/nba/playoffs/` and confirm the 4/5/6/7 swatches in the legend are smaller but still clearly colour-coded.

https://claude.ai/code/session_01EL3TfZAkxxNfkP38Tfguep