### PR TITLE
NBA playoff bracket: simpler round labels

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -101,6 +101,9 @@
     font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
     color: var(--dim); font-weight: 600; margin-bottom: 12px;
   }
+  /* Keep empty titles in the layout so alignment across columns/panels
+     stays consistent even when a round doesn't render a label. */
+  .col-title:empty::before { content: "\00a0"; }
 
   /* round-nav shows only on mobile */
   .round-nav { display: none; }
@@ -469,17 +472,17 @@ function render(slotList, { nSims, year }) {
     ${roundSection("r1",
       e_r1.map(s => slotCard(s, { maxShown: 4, label: r1Label(s) })).join(""),
       w_r1.map(s => slotCard(s, { maxShown: 4, label: r1Label(s) })).join(""),
-      "East · 1st Round", "West · 1st Round")}
+      "East", "West")}
     ${roundSection("semis",
       e_r2.map(s => slotCard(s, { maxShown: 4, label: r2Label(s) })).join(""),
       w_r2.map(s => slotCard(s, { maxShown: 4, label: r2Label(s) })).join(""),
-      "East · Conf Semis", "West · Conf Semis")}
+      "", "")}
     ${roundSection("cf",
       e_cf.map(s => slotCard(s, { maxShown: 6, label: "Conf Finals" })).join(""),
       w_cf.map(s => slotCard(s, { maxShown: 6, label: "Conf Finals" })).join(""),
-      "East · Conf Finals", "West · Conf Finals")}
+      "", "")}
     <div class="round finals" data-round="finals">
-      <div class="col-title">Finals</div>
+      <div class="col-title"></div>
       <div class="col-cards">${fin.map(s => slotCard(s, { maxShown: 10, label: "NBA Finals" })).join("")}</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace the per-round conference labels ("East · Conf Semis", "West · Conf Finals", "Finals", etc.) with just "East" / "West" on the R1 slot; Semis, CF, and Finals render no column title at all. Each card already carries its own round-tag (e.g. "Conf Semis · 1–4 bracket", "NBA Finals"), so the column labels were redundant.
- Keep the empty `col-title` divs so they still occupy a consistent row in the mobile grid template and preserve desktop column heights; added `col-title:empty::before { content: "\00a0" }` to reserve visual height.

## Test plan
- [ ] Desktop: only the leftmost column shows "East" / "West" labels. Semis/CF/Finals columns have blank title space above the cards, and card positions / connector lines remain aligned.
- [ ] Mobile: the R1 panel shows "East" / "West". Other panels have no conference headings, and the vertical card alignment across swipes is unchanged.

https://claude.ai/code/session_01EL3TfZAkxxNfkP38Tfguep