### PR TITLE
NBA playoff bracket: drop 'Matchup' label, show bare 0–0 record

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -437,13 +437,13 @@ function seriesBanner(s) {
   const aw = gw[a.abbr] ?? 0, bw = gw[b.abbr] ?? 0;
   const status = s.series.status;
   const labelMap = {
-    not_started: "Matchup",
+    not_started: "",
     in_progress: "Series",
     complete: "Final"
   };
-  const label = labelMap[status] || "Series";
+  const label = labelMap[status] ?? "Series";
   return `<div class="series-score ${status === 'complete' ? 'is-final' : ''}">
-    <span class="series-label">${label}</span>
+    ${label ? `<span class="series-label">${label}</span>` : ""}
     <span class="series-score-line">${a.abbr} ${aw} <span class="dash">–</span> ${bw} ${b.abbr}</span>
   </div>`;
 }


### PR DESCRIPTION
## Summary
- For a locked-but-not-started series, render just the bare score (e.g. `NYK 0 – 0 ATL`) with no label prefix — the 0–0 already conveys the state.
- `Series` and `Final` labels remain for the `in_progress` and `complete` states.

## Test plan
- [ ] Four locked R1 slots (E 3-6, E 4-5, W 3-6, W 4-5) show just `NYK 0 – 0 ATL` without a `Matchup` prefix.

https://claude.ai/code/session_01EL3TfZAkxxNfkP38Tfguep