### PR TITLE
Lean bracket cards into the card metaphor

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -501,7 +501,7 @@ function slotCard(s, opts = {}) {
   const toggleBtn = rest.length > 0 ? `
     <button class="expand-btn" data-target="${id}" aria-expanded="false">
       <span class="expand-closed">${rest.length} more · ${fmtPct(restWin)}</span>
-      <span class="expand-open">show less</span>
+      <span class="expand-open">show fewer</span>
       <span class="expand-caret" aria-hidden="true">&#9662;</span>
     </button>` : "";
   const header = `<div class="round-tag">${label || s.slot}</div>`;

--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -3,13 +3,14 @@
 <style>
   .bracket-scope {
     --bg: #ffffff;
-    --panel: #ffffff;
+    --panel: #fafafa;
     --ink: #313131;
     --text: #515151;
     --dim: #666;
     --faint: #aaa;
     --rule: #cccccc;
     --rule-strong: #333;
+    --card-rule: #b0b0b0;
     --row-rule: #eeeeee;
     --bar-bg: #eeeeee;
     --accent: #33CEFF;
@@ -109,7 +110,8 @@
   .round-nav { display: none; }
 
   .match {
-    background: var(--panel); border: 1px solid var(--rule);
+    background: var(--panel); border: 1px solid var(--card-rule);
+    border-radius: 3px;
     padding: 10px 12px; position: relative;
   }
   .match .round-tag {
@@ -172,15 +174,31 @@
   .team.eliminated .team-dot { opacity: 0.5; }
 
   .expand-btn {
-    display: block; width: 100%; margin-top: 6px; padding: 5px 0;
-    background: none; border: none; border-top: 1px dashed var(--rule);
-    font-family: inherit; font-size: 11px; color: var(--dim); cursor: pointer;
-    text-align: center;
+    display: flex; align-items: center; justify-content: center; gap: 6px;
+    width: calc(100% + 24px);
+    margin: 10px -12px -10px;
+    padding: 7px 10px;
+    background: rgba(0, 0, 0, 0.025);
+    border: none;
+    border-top: 1px solid var(--card-rule);
+    border-radius: 0 0 2px 2px;
+    font-family: inherit; font-size: 11px; color: var(--text); cursor: pointer;
+    transition: background 0.15s, color 0.15s;
   }
-  .expand-btn:hover { color: var(--ink); }
+  .expand-btn:hover,
+  .expand-btn:focus-visible {
+    background: rgba(0, 0, 0, 0.055);
+    color: var(--ink);
+    outline: none;
+  }
   .expand-btn .expand-open { display: none; }
   .match.expanded .expand-btn .expand-closed { display: none; }
   .match.expanded .expand-btn .expand-open { display: inline; }
+  .expand-btn .expand-caret {
+    display: inline-block; font-size: 9px; line-height: 1;
+    transition: transform 0.15s ease;
+  }
+  .match.expanded .expand-btn .expand-caret { transform: rotate(180deg); }
 
   footer.foot {
     margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--rule);
@@ -482,8 +500,9 @@ function slotCard(s, opts = {}) {
   const expandedRows = teams.map((c,i) => teamRow(c, i === 0, series)).join("");
   const toggleBtn = rest.length > 0 ? `
     <button class="expand-btn" data-target="${id}" aria-expanded="false">
-      <span class="expand-closed">+ ${rest.length} more · ${fmtPct(restWin)}</span>
-      <span class="expand-open">collapse</span>
+      <span class="expand-closed">${rest.length} more · ${fmtPct(restWin)}</span>
+      <span class="expand-open">show less</span>
+      <span class="expand-caret" aria-hidden="true">&#9662;</span>
     </button>` : "";
   const header = `<div class="round-tag">${label || s.slot}</div>`;
   const cardCls = ["match"];


### PR DESCRIPTION
- Tint card panel barely off-white (#fafafa) so cards sit just above
  the page background instead of blending into it.
- Introduce --card-rule (#b0b0b0), stronger than --rule, for a more
  defined card edge; add a 3px border-radius.
- Rework the expand/collapse affordance from a tiny dashed divider
  into a proper card footer: subtle tinted band, solid top rule,
  rotating chevron, larger tap target, hover/focus states. Drops
  the redundant '+' prefix (now signaled by the caret).