### PR TITLE
Papery bracket cards + declutter playoffs page top

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -321,7 +321,7 @@
     /* round indicator bar above the scroll area */
     .round-nav {
       display: flex; gap: 6px; justify-content: center;
-      margin-bottom: 10px;
+      margin-bottom: 24px;
     }
     .round-nav button {
       flex: 1; max-width: 80px;

--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -3,16 +3,16 @@
 <style>
   .bracket-scope {
     --bg: #ffffff;
-    --panel: #fafafa;
+    --panel: #fbf6eb;
     --ink: #313131;
     --text: #515151;
-    --dim: #666;
-    --faint: #aaa;
-    --rule: #cccccc;
-    --rule-strong: #333;
-    --card-rule: #b0b0b0;
-    --row-rule: #eeeeee;
-    --bar-bg: #eeeeee;
+    --dim: #706a5c;
+    --faint: #a8a08d;
+    --rule: #d4cab4;
+    --rule-strong: #3a3528;
+    --card-rule: #a89879;
+    --row-rule: #eae0ca;
+    --bar-bg: #eae0ca;
     --accent: #33CEFF;
     --s4: #6b92c2;
     --s5: #7fb5cc;
@@ -30,6 +30,12 @@
   header.hero { margin-bottom: 24px; }
   header.hero h1 { margin: 0 0 4px; font-size: 22px; font-weight: 600; color: var(--ink); }
   header.hero .meta { color: var(--dim); font-size: 13px; }
+  header.hero .back-link {
+    display: inline-block; margin-bottom: 10px;
+    font-size: 11px; letter-spacing: 0.02em;
+    color: var(--dim) !important; text-decoration: none;
+  }
+  header.hero .back-link:hover { color: var(--ink) !important; }
 
   .legend {
     display: flex; gap: 18px; flex-wrap: wrap; align-items: center;
@@ -334,8 +340,9 @@
 <div class="wrap">
 
 <header class="hero">
-  <h1 style="margin:0 0 4px; font-size:22px; font-weight:600; color:var(--ink);">Playoff Bracket <span id="year-label" style="color: var(--dim); font-weight: 400;"></span></h1>
-  <div class="meta" id="sim-meta" style="color:var(--dim); font-size:13px;">loading sims…</div>
+  <a class="back-link" href="/nba/">← NBA Forecast</a>
+  <h1>Playoff Bracket</h1>
+  <div class="meta" id="sim-meta">loading sims…</div>
 </header>
 
 <div class="legend">
@@ -518,7 +525,6 @@ function slotCard(s, opts = {}) {
 }
 
 function render(slotList, { nSims, year }) {
-  document.getElementById("year-label").textContent = `— ${year} Forecast`;
   document.getElementById("sim-meta").textContent = `${nSims.toLocaleString()} sims · updated ${new Date().toISOString().slice(0,10)}`;
 
   const bySlot = key => slotList.find(s => `${s.round}|${s.conf}|${s.slot}` === key);

--- a/nba/playoffs.md
+++ b/nba/playoffs.md
@@ -23,8 +23,7 @@ html { font-size: 16px !important; }
   html { font-size: 20px !important; }
 }
 .masthead { display: none !important; }
+.page-title { display: none !important; }
 </style>
-
-<p><a href="/nba/">← NBA Forecast</a></p>
 
 {% include nba_playoff_bracket.html %}


### PR DESCRIPTION
## Summary

Leans bracket match cards into the card metaphor and tidies the top of the playoffs page.

**Cards feel more like cards**
- New warm papery palette: `--panel` → `#fbf6eb`, `--card-rule` → `#a89879` (higher contrast than the old `#cccccc` and warm instead of neutral grey)
- All surrounding greys (`--rule`, `--row-rule`, `--bar-bg`, `--dim`, `--faint`, `--rule-strong`) shifted warm to harmonize with the cream cards
- Small 3px border-radius on `.match`

**Expand / collapse more obviously tappable**
- Replaced the tiny dashed top-rule with a footer-style button: subtle tinted band, solid top border in the card-rule color, rotating `▾` chevron, bigger hit target, hover + `:focus-visible` states
- Label changed to "N more · XX%" / "show fewer" (chevron now carries the +/− affordance)

**Declutter the playoffs page top**
- Hide the layout's `.page-title` so "Playoff Bracket" only appears once
- Drop the "— YYYY Forecast" suffix from the H1 (meta line already carries the date)
- Move the "← NBA Forecast" back link into the bracket hero so it inherits the bracket's monospace font (was showing in the page body font)
- Bump mobile `.round-nav` `margin-bottom` from 10px → 24px so the round menu doesn't crowd the "East" title

## Test plan

- [ ] Visit `/nba/playoffs/` on desktop — cards read as warm paper, single "Playoff Bracket" title, back link is monospace
- [ ] Hover a card — per-team distribution tooltip still appears and isn't clipped
- [ ] Expand a card — chevron rotates, button shows subtle hover/active state, "N more · XX%" ↔ "show fewer" swap works
- [ ] Mobile: swipe between rounds, confirm spacing between round-nav and East title feels roomy
- [ ] Mobile: tap expand/collapse on a card, confirm hit target feels like a real button
