### PR TITLE
Cool the playoff card palette toward neutral grays

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -3,16 +3,16 @@
 <style>
   .bracket-scope {
     --bg: #ffffff;
-    --panel: #fbf6eb;
+    --panel: #f7f7f5;
     --ink: #313131;
     --text: #515151;
-    --dim: #706a5c;
-    --faint: #a8a08d;
-    --rule: #d4cab4;
-    --rule-strong: #3a3528;
-    --card-rule: #a89879;
-    --row-rule: #eae0ca;
-    --bar-bg: #eae0ca;
+    --dim: #8a8a8a;
+    --faint: #b5b5b5;
+    --rule: #e6e6e6;
+    --rule-strong: #313131;
+    --card-rule: #e0e0e0;
+    --row-rule: #ececec;
+    --bar-bg: #ececec;
     --accent: #33CEFF;
     --s4: #6b92c2;
     --s5: #7fb5cc;


### PR DESCRIPTION
Cards previously used a warm sepia panel (#fbf6eb) with a strong tan
border against a pure white body, which created a jarring warm-on-white
contrast. Swap the panel, rules, and dim/faint text to neutral near-white
grays so cards sit just slightly off the background.

https://claude.ai/code/session_01H9LuGeYxQ2hNuZzicsaErn