### PR TITLE
Cool NBA playoff cards toward paper-white

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -3,16 +3,16 @@
 <style>
   .bracket-scope {
     --bg: #ffffff;
-    --panel: #f7f7f5;
+    --panel: #fcfcfb;
     --ink: #313131;
     --text: #515151;
-    --dim: #8a8a8a;
-    --faint: #b5b5b5;
-    --rule: #e6e6e6;
+    --dim: #9a9a9a;
+    --faint: #c2c2c2;
+    --rule: #efefef;
     --rule-strong: #313131;
-    --card-rule: #e0e0e0;
-    --row-rule: #ececec;
-    --bar-bg: #ececec;
+    --card-rule: #ebebeb;
+    --row-rule: #f2f2f2;
+    --bar-bg: #eaeaea;
     --accent: #33CEFF;
     --s4: #6b92c2;
     --s5: #7fb5cc;


### PR DESCRIPTION
## Summary
- Swap the warm sepia card palette (cream panel + tan border) for neutral near-white tones so the bracket cards sit just slightly off the white body instead of as warm chips on white.
- Nudge the panel up to `#fcfcfb` (near paper-white) and soften the border, row-rule, and dim/faint text so contrast reads tasteful rather than loud.
- Leave the series-length data-viz colors (`--s4`–`--s7`) alone — they carry meaning. `--bar-bg` stays a touch darker (`#eaeaea`) so the empty-series track remains visible behind the colored probability segments.

## Test plan
- [ ] Visit `/nba/playoffs/` and confirm the cards are just barely distinguishable from the background with no warm cast.
- [ ] Verify team rows, dividers, series-score banners, and the expand footer still render cleanly.
- [ ] Check the series-length bars still read clearly inside the softer card background.
- [ ] Spot-check responsive breakpoints (mobile round-nav, tablet Finals row).

https://claude.ai/code/session_01H9LuGeYxQ2hNuZzicsaErn