### PR TITLE
Shift playoff bar ramp from blue to blue-to-teal

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -14,10 +14,10 @@
     --row-rule: #f0f0f0;
     --bar-bg: #eaeaea;
     --accent: #33CEFF;
-    --s4: #dde1e6;
-    --s5: #a8b1bd;
-    --s6: #6e7987;
-    --s7: #3b4553;
+    --s4: #d5e3ea;
+    --s5: #9ebfc8;
+    --s6: #5d9497;
+    --s7: #2e6668;
     background: var(--bg); color: var(--text);
   }
   * { box-sizing: border-box; }
@@ -148,11 +148,11 @@
   }
   .dist .bar { display: flex; height: 5px; background: var(--bar-bg); }
 
-  /* Single-hue sequential slate ramp — 4g palest to 7g deepest */
-  .s4 { background: var(--s4, #dde1e6); }  /* palest slate — 4 games */
-  .s5 { background: var(--s5, #a8b1bd); }  /* light slate  — 5 games */
-  .s6 { background: var(--s6, #6e7987); }  /* mid slate    — 6 games */
-  .s7 { background: var(--s7, #3b4553); }  /* deep slate   — 7 games */
+  /* Blue-to-teal sequential ramp — 4g pale cool blue to 7g deep teal */
+  .s4 { background: var(--s4, #d5e3ea); }  /* pale blue  — 4 games */
+  .s5 { background: var(--s5, #9ebfc8); }  /* cyan       — 5 games */
+  .s6 { background: var(--s6, #5d9497); }  /* teal       — 6 games */
+  .s7 { background: var(--s7, #2e6668); }  /* deep teal  — 7 games */
 
   .team.dog .team-name .abbr { color: var(--dim); font-weight: 500; }
 


### PR DESCRIPTION
Obsolete — pushed the revert to the original multi-hue bar palette straight to master (commit 0d6ff98).