### PR TITLE
Drop line-through on eliminated team in completed series

### DIFF
--- a/_includes/nba_playoff_bracket.html
+++ b/_includes/nba_playoff_bracket.html
@@ -170,7 +170,7 @@
   /* winner + eliminated flags for completed series */
   .team.winner .team-name .abbr,
   .team.winner .win-pct { font-weight: 700; }
-  .team.eliminated .team-name .abbr { text-decoration: line-through; color: var(--dim); }
+  .team.eliminated .team-name .abbr { color: var(--dim); }
   .team.eliminated .team-name .full,
   .team.eliminated .seed,
   .team.eliminated .win-pct,


### PR DESCRIPTION
## Summary
- Drops the `text-decoration: line-through` on eliminated-team abbreviations in completed-series bracket cards. The dim color + reduced opacity already make the eliminated state clear.

## Test plan
- [ ] Load `/nba/playoffs/` and confirm the loser of a completed series shows in dim/grey but is no longer struck through.
- [ ] Confirm the winner is still bolded and the rest of the layout is unchanged.

https://claude.ai/code/session_01TB8qs3oCVmUzchg2peA8ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB8qs3oCVmUzchg2peA8ZE)_